### PR TITLE
Handle calling convention differences

### DIFF
--- a/tests/std/tests/kernel.lst
+++ b/tests/std/tests/kernel.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-PM_CL="/kernel /Zc:preprocessor /std:c++latest /w14640 /Zc:threadSafeInit- /DNO_TEST_ENVIRONMENT_PREPARER" PM_LINK="/IGNORE:4210 /entry:DriverEntry /subsystem:native /nodefaultlib stl_kernel.lib BufferOverflowFastFailK.lib ntoskrnl.lib hal.lib wmilib.lib Ntstrsafe.lib libcpmt.lib libcmt.lib"
+PM_CL="/kernel /Zc:preprocessor /std:c++latest /w14640 /Zc:threadSafeInit- /DNO_TEST_ENVIRONMENT_PREPARER" PM_LINK="/IGNORE:4210 /subsystem:native /nodefaultlib stl_kernel.lib BufferOverflowFastFailK.lib ntoskrnl.lib hal.lib wmilib.lib Ntstrsafe.lib libcpmt.lib libcmt.lib"

--- a/tests/utils/kernel/CMakeLists.txt
+++ b/tests/utils/kernel/CMakeLists.txt
@@ -28,7 +28,13 @@ target_include_directories(stl_kernel PRIVATE
 )
 
 # TRANSITION, WDK needs to suppress C5040
-target_compile_options(stl_kernel PRIVATE /kernel /wd5040)
+if(VCLIBS_TARGET_ARCHITECTURE STREQUAL "x86")
+    set(STL_KERNEL_CALLING_CONVENTION "/Gz")
+else()
+    set(STL_KERNEL_CALLING_CONVENTION "")
+endif()
+
+target_compile_options(stl_kernel PRIVATE /kernel /wd5040 ${STL_KERNEL_CALLING_CONVENTION})
 
 add_executable(stl_kernel_loader ${STL_KERNEL_LOADER_SOURCES})
 target_include_directories(stl_kernel_loader PRIVATE

--- a/tests/utils/kernel/src/stl_kernel/stl_kernel.cpp
+++ b/tests/utils/kernel/src/stl_kernel/stl_kernel.cpp
@@ -58,6 +58,7 @@ DRIVER_UNLOAD PAGE, StlKernelUnloadDriver;
 #pragma alloc_text(PAGE, StlKernelDeviceControl)
 #pragma alloc_text(PAGE, StlKernelUnloadDriver)
 
+_Use_decl_annotations_
 NTSTATUS DriverEntry(DRIVER_OBJECT* driver, UNICODE_STRING* /*reg_path*/) {
     UNICODE_STRING nt_name;
     RtlInitUnicodeString(&nt_name, STL_KERNEL_NT_DEVICE_NAME);

--- a/tests/utils/kernel/src/stl_kernel/test_decls.h
+++ b/tests/utils/kernel/src/stl_kernel/test_decls.h
@@ -8,4 +8,4 @@ extern const wchar_t* const STL_KERNEL_NT_DEVICE_NAME;
 extern const wchar_t* const STL_KERNEL_DOS_DEVICE_NAME;
 extern KGUARDED_MUTEX g_assert_mutex;
 
-extern "C" int main();
+extern "C" int __cdecl main();

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -202,7 +202,6 @@ class STLTest(Test):
 
     def _parseFlags(self, litConfig):
         foundStd = False
-        isKernel = False
         for flag in chain(self.flags, self.compileFlags, self.linkFlags):
             if flag[1:5] == 'std:':
                 foundStd = True
@@ -226,18 +225,16 @@ class STLTest(Test):
                 self.requires.append('arch_vfpv4') # available for arm, see features.py
             elif flag[1:] == 'kernel':
                 self.requires.append('kernel')
-                isKernel = True
-
-        if isKernel:
-            targetArch = litConfig.target_arch.casefold()
-            if (targetArch == 'x86'.casefold()):
-                # 32-bit kernel uses stdcall by default
-                self.compileFlags.append('/Gz')
-                self.compileFlags.append('/wd4007')
-                self.linkFlags.append('/entry:DriverEntry@8')
-            else:
-                self.linkFlags.append('/entry:DriverEntry')
-
+                # TRANSITION, We should support kernel mode tests on all platforms
+                self.requires.append('x64')
+                targetArch = litConfig.target_arch.casefold()
+                if (targetArch == 'x86'.casefold()):
+                    # 32-bit kernel uses stdcall by default
+                    self.compileFlags.append('/Gz')
+                    self.compileFlags.append('/wd4007')
+                    self.linkFlags.append('/entry:DriverEntry@8')
+                else:
+                    self.linkFlags.append('/entry:DriverEntry')
 
         if not foundStd:
             Feature('c++14').enableIn(self.config)

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -50,7 +50,7 @@ class STLTest(Test):
 
         self._handleEnvlst(litConfig)
         self._parseTest()
-        self._parseFlags()
+        self._parseFlags(litConfig)
 
         missing_required_features = self.getMissingRequiredFeatures()
         if missing_required_features:
@@ -200,8 +200,9 @@ class STLTest(Test):
 
         self.cxx = os.path.normpath(cxx)
 
-    def _parseFlags(self):
+    def _parseFlags(self, litConfig):
         foundStd = False
+        isKernel = False
         for flag in chain(self.flags, self.compileFlags, self.linkFlags):
             if flag[1:5] == 'std:':
                 foundStd = True
@@ -225,6 +226,18 @@ class STLTest(Test):
                 self.requires.append('arch_vfpv4') # available for arm, see features.py
             elif flag[1:] == 'kernel':
                 self.requires.append('kernel')
+                isKernel = True
+
+        if isKernel:
+            targetArch = litConfig.target_arch.casefold()
+            if (targetArch == 'x86'.casefold()):
+                # 32-bit kernel uses stdcall by default
+                self.compileFlags.append('/Gz')
+                self.compileFlags.append('/wd4007')
+                self.linkFlags.append('/entry:DriverEntry@8')
+            else:
+                self.linkFlags.append('/entry:DriverEntry')
+
 
         if not foundStd:
             Feature('c++14').enableIn(self.config)


### PR DESCRIPTION
"ninja" was successful on all four platforms (amd64, x86, arm, arm64).

Running `python tests\utils\stl-lit\stl-lit.py ..\..\..\tests\std\tests\Dev11_0863628_atomic_compare_exchange` succeeded on x64 (because I'm testing on an x64 system).  On x86, the compile and link portions worked, but running failed (as expected) because I'm not running an x86 kernel.  On arm and arm64, running the kernel loader failed, as expected, because it's an arm executable, not an x86 executable.