### PR TITLE
Always compile kernel tests, but only run on x64

### DIFF
--- a/tests/utils/stl/test/format.py
+++ b/tests/utils/stl/test/format.py
@@ -188,7 +188,7 @@ class STLTestFormat:
         elif TestType.RUN in test.testType:
             shared.execFile = tmpBase + '.exe'
             isKernel = 'kernel' in test.requires
-            needsSigning = False
+
             if isKernel:
                 name = str(shared.execFile).replace('\\','.').replace(':','.')
 
@@ -205,15 +205,13 @@ class STLTestFormat:
                     '/machine:'+litConfig.target_arch,
                 ])
 
-                # only sign (and run) kernel mode tests on x64
-                needsSigning = (litConfig.target_arch == 'x64'.casefold())
-
             # common path for kernel and non-kernel
             cmd = [test.cxx, test.getSourcePath(), *test.flags, *test.compileFlags,
                    '/Fe' + shared.execFile, '/link', *test.linkFlags]
             yield TestStep(cmd, shared.execDir, shared.env, False)
 
-            if needsSigning:
+            # only sign (and run) kernel mode tests on x64
+            if isKernel and 'x64' in test.requires:
                 # sign the binary
                 cmd = [litConfig.wdk_bin + '/x86/signtool.exe', 'sign',
                        '/f', litConfig.cert_path,


### PR DESCRIPTION
Added some hacked in prints to validate that I'm still doing kernel execution for x64.  x86 tests pass.

Actually running on a different (ARM) machine is totally possible, but I'd need to know what the setup looks like and how paths are setup.  For now, I'm just going with compilation and linking coverage.